### PR TITLE
Add symlink for kube-fzf.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ sudo ln -s ~/.kube-fzf/execpod /usr/local/bin/execpod
 sudo ln -s ~/.kube-fzf/tailpod /usr/local/bin/tailpod
 sudo ln -s ~/.kube-fzf/describepod /usr/local/bin/describepod
 sudo ln -s ~/.kube-fzf/pfpod /usr/local/bin/pfpod
+sudo ln -s ~/.kube-fzf/kube-fzf.sh  /usr/local/bin/kube-fzf.sh
 ```
 
 ## Usage


### PR DESCRIPTION
Without the missing symlink, this error occur:

```
/usr/local/bin/execpod: line 3: kube-fzf.sh: No such file or directory
/usr/local/bin/execpod: line 8: _kube_fzf_handler: command not found
/usr/local/bin/execpod: line 8: _kube_fzf_teardown: command not found
```